### PR TITLE
Add gentoo ebuilds

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ netcat across UNIXes.
 Distribution Packages:
 - [Arch](https://aur.archlinux.org/packages/mpvc-git) - `pacaur -y mpvc-git`
 - [Crux](https://github.com/wildefyr/wild-crux-ports) - `prt-get depinst mpvc`
+- [Gentoo](https://gitlab.com/xy2_/osman) - `emerge mpvc`
 
 If you have packaged mpvc for your distribution, let me know so I can add it here.
 


### PR DESCRIPTION
Located in the osman overlay, addable with "layman -o https://gitlab.com/xy2_/osman/raw/master/osman-overlay.xml -f -a osman"
